### PR TITLE
Improve performance by making the function inline, and simplify code

### DIFF
--- a/kroom/src/main/java/org/ligi/kroom/RoomFun.kt
+++ b/kroom/src/main/java/org/ligi/kroom/RoomFun.kt
@@ -2,9 +2,9 @@ package org.ligi.kroom
 
 import android.arch.persistence.room.RoomDatabase
 
-fun <T : RoomDatabase> T.inTransaction(call: T.() -> Unit) = try {
+inline fun <T : RoomDatabase> T.inTransaction(transaction: T.() -> Unit) = try {
     beginTransaction()
-    call.invoke(this)
+    transaction()
     setTransactionSuccessful()
 } finally {
     endTransaction()


### PR DESCRIPTION
Adding the inline keywords equals to writing the transaction manually, instead of allocating a throwaway anonymous class otherwise.
Also, since `T` is the receiver, you can just invoke `call` (which I renamed to `transaction`) like an extension function.